### PR TITLE
Item drop rate

### DIFF
--- a/db/Changelog.txt
+++ b/db/Changelog.txt
@@ -9,6 +9,8 @@
 	13005 Angelic Wing Dagger:	NEED INFO.
 =======================
 
+2012/08/29
+	* Rev. 15179 Implemented db/item_drop_rate.txt (see file for more info) [Hybrid]
 2012/08/12
 	* Rev. 15176 Updated mapcache up to 2012-08-08. Adds WoE TE, Malaya, Eclage, Hall of Abyss and Izlude Novice Tutorial maps. [Ai4rei]
 2011/11/03

--- a/db/item_drop_rate.txt
+++ b/db/item_drop_rate.txt
@@ -1,0 +1,9 @@
+// Item Drop Rate Database
+//
+// This file overrides all other drop rate modifiers
+//
+// Structure: itemid, dummyname, droprate
+//
+// Example:
+//4001,Poring_Card,1000 // Sets Poring Card to 10% droprate
+// Note: This gets reloaded with @reloadmobdb

--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -826,6 +826,7 @@ static bool itemdb_parse_dbrow(char** str, const char* source, int line, int scr
 		id->equip_script = parse_script(str[20], source, line, scriptopt);
 	if (*str[21])
 		id->unequip_script = parse_script(str[21], source, line, scriptopt);
+	id->fix_rate = 0;
 
 	return true;
 }

--- a/src/map/itemdb.h
+++ b/src/map/itemdb.h
@@ -85,6 +85,7 @@ struct item_data {
 		unsigned buyingstore : 1;
 	} flag;
 	short gm_lv_trade_override;	//GM-level to override trade_restriction
+	short fix_rate; // Fixed drop rate of an item [Hybrid]
 };
 
 struct item_group {
@@ -97,6 +98,7 @@ int itemdb_searchname_array(struct item_data** data, int size, const char *str);
 struct item_data* itemdb_load(int nameid);
 struct item_data* itemdb_search(int nameid);
 struct item_data* itemdb_exists(int nameid);
+#define item_fix_rate(n) itemdb_search(n)->fix_rate
 #define itemdb_name(n) itemdb_search(n)->name
 #define itemdb_jname(n) itemdb_search(n)->jname
 #define itemdb_type(n) itemdb_search(n)->type

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -3570,6 +3570,10 @@ static bool mob_parse_dbrow(char** str)
 			db->dropitem[i].p = 0; //No drop.
 			continue;
 		}
+		if ( item_fix_rate(db->dropitem[i].nameid) > 0 ) {
+			 db->dropitem[i].p = item_fix_rate (db->dropitem[i].nameid);
+			 continue;
+		}
 		type = itemdb_type(db->dropitem[i].nameid);
 		rate = atoi(str[k+1]);
 		if( (class_ >= 1324 && class_ <= 1363) || (class_ >= 1938 && class_ <= 1946) )
@@ -4272,8 +4276,31 @@ static bool mob_readdb_race2(char* fields[], int columns, int current)
 	return true;
 }
 
+// Reads items' fixed drop rates [Hybrid]
+static bool item_read_drop_rate (char* fields[], int columns, int current) {
+	int nameid, rate;
+	struct item_data* id;
+
+	nameid = atoi(fields[0]);
+
+	if( ( id = itemdb_exists(nameid) ) == NULL ) {
+		ShowWarning("item_read_drop_rate: Invalid item id %d.\n", nameid);
+		return false;
+	}
+	rate = atoi (fields[2]);
+	
+	if ( rate < 1 || rate > 10000 ) { // Rate of 0 is reserved as default value [Hybrid]
+		ShowWarning("item_read_drop_rate: Invalid rate %r. \n", rate);
+	}
+	id->flag.fix_rate = rate;
+
+	return true;
+}
+
 static void mob_load(void)
 {
+	// Read in fixed rates before evaluating anything
+	sv_readdb(db_path, "item_drop_rate.txt", ',', 3, 3, -1,           &item_read_drop_rate);
 #ifndef TXT_ONLY
 	if(db_use_sqldbs)
 		mob_read_sqldb();


### PR DESCRIPTION
Allows for server-wide edit to the drop rate of a single item, permitting it to be set at a specific value (i.e. making it so ALL monsters who drop Jellopy drop it at, say, 50% chance)
